### PR TITLE
Dev/ono/line trace

### DIFF
--- a/src/common/app/lineMonitor.cpp
+++ b/src/common/app/lineMonitor.cpp
@@ -1,8 +1,9 @@
 /**
  * @brief LineMonitor.cpp
  */
-
+#include <stdio.h>
 #include "lineMonitor.h"
+
 
 LineMonitor::LineMonitor(ColorSensor& colorSensor) : 
     mColorSensor(colorSensor) {
@@ -12,14 +13,24 @@ SDWORD LineMonitor::getReflection(void) {
     return mColorSensor.getReflection();
 }
 
-bool LineMonitor::isRGBThExceeded(WORD wRGBR, WORD wRGBG, WORD wRGBB) {
+bool LineMonitor::isRGBThExceeded(WORD wRGBRth_Max, WORD wRGBGth_Max, WORD wRGBBth_Max, WORD wRGBRth_Min, WORD wRGBGth_Min, WORD wRGBBth_Min) {
     // RGB閾値チェックの実装
     mColorSensor.getRGB(p_RGB);
-    return ((wRGBR > p_RGB.r) || (wRGBG > p_RGB.g) || (wRGBB > p_RGB.b));
+    // printf("R: %d, G: %d, B: %d\n", p_RGB.r, p_RGB.g, p_RGB.b);
+    // printf("Thresholds - R: %d, G: %d, B: %d\n", wRGBRth_Max, wRGBGth_Max, wRGBBth_Max);
+    bool aboveMax = (p_RGB.r < wRGBRth_Max) && (p_RGB.g < wRGBGth_Max) && (p_RGB.b < wRGBBth_Max);
+    bool belowMin = (p_RGB.r > wRGBRth_Min) && (p_RGB.g > wRGBGth_Min) && (p_RGB.b > wRGBBth_Min);
+    if(p_RGB.b > 120) {
+        printf("R: %d, G: %d, B: %d\n", p_RGB.r, p_RGB.g, p_RGB.b);
+    }
+    if(aboveMax && belowMin) {
+        printf("Line Detected! R: %d, G: %d, B: %d\n", p_RGB.r, p_RGB.g, p_RGB.b);
+    }
+    return aboveMax && belowMin;
 }
 
 
-bool LineMonitor::isLineDetected(WORD wRGBR, WORD wRGBG, WORD wRGBB) {
+bool LineMonitor::isLineDetected(WORD wRGBRth_Max, WORD wRGBGth_Max, WORD wRGBBth_Max, WORD wRGBRth_Min, WORD wRGBGth_Min, WORD wRGBBth_Min) {
     // 線の検出ロジック
-    return isRGBThExceeded(wRGBR, wRGBG, wRGBB);
+    return isRGBThExceeded(wRGBRth_Max, wRGBGth_Max, wRGBBth_Max, wRGBRth_Min, wRGBGth_Min, wRGBBth_Min);
 }

--- a/src/common/app/lineMonitor.h
+++ b/src/common/app/lineMonitor.h
@@ -8,10 +8,10 @@ class LineMonitor {
     public:
         LineMonitor(ColorSensor& colorSensor);
         SDWORD getReflection(void);
-        bool isLineDetected(WORD wRGBR, WORD wRGBG, WORD wRGBB);
+        bool isLineDetected(WORD wRGBRth_Max, WORD wRGBGth_Max, WORD wRGBBth_Max, WORD wRGBRth_Min, WORD wRGBGth_Min, WORD wRGBBth_Min);
     
     private:
         ColorSensor& mColorSensor;
         ColorSensor::RGB p_RGB; // RGB値を格納する構造体
-        bool isRGBThExceeded(WORD wRGBR, WORD wRGBG, WORD wRGBB);
+        bool isRGBThExceeded(WORD wRGBRth_Max, WORD wRGBGth_Max, WORD wRGBBth_Max, WORD wRGBRth_Min, WORD wRGBGth_Min, WORD wRGBBth_Min);
 };

--- a/src/common/app/pidCtrl.cpp
+++ b/src/common/app/pidCtrl.cpp
@@ -37,8 +37,8 @@ SDWORD PidCtrl::Calculate_001(WORD wTarget, WORD wCurrent)
         nDerivative = nError - m_anPrevError[0];
     }
 
-    printf("PidCtrl::Calculate_001() called. Target: %d, Current: %d, Error: %d, Integral: %d, Derivative: %d\n",
-           wTarget, wCurrent, nError, m_nIntegral, nDerivative);
+    // printf("PidCtrl::Calculate_001() called. Target: %d, Current: %d, Error: %d, Integral: %d, Derivative: %d\n",
+    //        wTarget, wCurrent, nError, m_nIntegral, nDerivative);
     // PID制御計算
     SDWORD lOutput = (m_wKp * nError) + (m_wKi * m_nIntegral) + (m_wKd * nDerivative);
 

--- a/src/common/mid/timer.cpp
+++ b/src/common/mid/timer.cpp
@@ -47,6 +47,8 @@ bool Timer::isTimeout(void) {
     
     DWORD currentTime_MS = mClock.now();
     if ((currentTime_MS - dwStartTime_MS) >= dwTimeoutDuration) {
+        printf("Timer timeout occurred.\n");
+        printf("Timer was running for %d milliseconds.\n", currentTime_MS - dwStartTime_MS);
         return true;
     }
     

--- a/src/common/mid/walker.cpp
+++ b/src/common/mid/walker.cpp
@@ -64,14 +64,14 @@ DWORD Walker::getLeftSpeed(void) {
  * @brief 右ホイールを止める
  */
 void Walker::stopRightWheel(void) {
-    return mRightWheel.stop();
+    return mRightWheel.setPower(0);
 }
 
 /**
  * @brief 左ホイールを止める
  */
 void Walker::stopLeftWheel(void) {
-    return mLeftWheel.stop();
+    return mLeftWheel.setPower(0);
 }
 
 /**

--- a/src/right/app/lineTrace.cpp
+++ b/src/right/app/lineTrace.cpp
@@ -4,15 +4,25 @@
 
 #include "lineTrace.h"
 
-#define DEFAULT_KP (10) /* デフォルトの比例ゲイン(0.01単位のパーセント) */
-#define DEFAULT_KI (10) /* デフォルトの積分ゲイン(0.01単位のパーセント) */
+/**
+ * TOP_pwm = 50
+ * #define DEFAULT_KP (1000) 
+ *  #define DEFAULT_KI (30) 
+    #define DEFAULT_KD (10)  
+    #define PID_TARGET (18)
+    がきれいにトレースできる
+ */
+// #define DEFAULT_KP (900) /* デフォルトの比例ゲイン(0.01単位のパーセント) */
+// #define DEFAULT_KI (25) /* デフォルトの積分ゲイン(0.01単位のパーセント) */
+// #define DEFAULT_KD (5) /* デフォルトの微分ゲイン(0.01単位のパーセント) */
+// #define PID_TARGET (20)
+// #define TOP_PWM (70) /* トップPWM値 */
+#define DEFAULT_KP (1000) /* デフォルトの比例ゲイン(0.01単位のパーセント) */
+#define DEFAULT_KI (30) /* デフォルトの積分ゲイン(0.01単位のパーセント) */
 #define DEFAULT_KD (10) /* デフォルトの微分ゲイン(0.01単位のパーセント) */
 #define PID_TARGET (18)
+#define TOP_PWM (10) /* トップPWM値 */
 
-#define TOP_PWM (30) /* トップPWM値 */
-#define RGB_R_THRESHOLD (0) /* RGB値Rしきい値 */
-#define RGB_G_THRESHOLD (0) /* RGB値Gしきい値 */
-#define RGB_B_THRESHOLD (255) /* RGB値Bしきい値 */
 
 using namespace Common;
 
@@ -21,11 +31,9 @@ LineTrace::LineTrace(Walker* pWalker, LineMonitor* pLineMonitor):
 {
     m_pidCtrl = new Caculation::PidCtrl();
     m_pidCtrl->setGains(DEFAULT_KP, DEFAULT_KI, DEFAULT_KD);
-}
+    m_stColorTh_Min = {50, 72, 120}; /* デフォルトは青色検知 */
+    m_stColorTh_Max = {70, 75, 255};
 
-void LineTrace::setColorTh(ST_COLOR_TH* pstColorTh)
-{
-    memcpy(&m_stColorTh, pstColorTh, sizeof(ST_COLOR_TH));
 }
 
 Common::ExecuteState LineTrace::excuteInitWalk(void)
@@ -34,27 +42,31 @@ Common::ExecuteState LineTrace::excuteInitWalk(void)
     /* TODO: ono ライントレース開始時の固定Runなかったかな？ */
     return Common::ExecuteState::Execute;
 }
-
+static bool isRunEnd = false;
 Common::ExecuteState LineTrace::executeTrace(void)
 {
     Common::ExecuteState eNextState = Common::ExecuteState::Execute;
+    if(isRunEnd) {
+        m_pWalker->setPWMForLineTrace(0, 0);
+        return eNextState;
+    }
     /* 青色を検知で終了 */
-    if(m_pLineMonitor->isLineDetected(m_stColorTh.wR, m_stColorTh.wG, m_stColorTh.wB)) {
-        eNextState = Common::ExecuteState::End;
+    if(m_pLineMonitor->isLineDetected(m_stColorTh_Max.wR, m_stColorTh_Max.wG, m_stColorTh_Max.wB, m_stColorTh_Min.wR, m_stColorTh_Min.wG, m_stColorTh_Min.wB)) {
+        // eNextState = Common::ExecuteState::End;
+        m_pWalker->setPWMForLineTrace(0, 0);
+        isRunEnd = true;
+        return eNextState;
     }
 
     /* Pid演算タスク */
     SDWORD dwPidResult = m_pidCtrl->Calculate_001(PID_TARGET, m_pLineMonitor->getReflection());
-    SWORD nBasePWM;
-    /* TODO:ono 昨年は低速モード作成していた */
-    nBasePWM = TOP_PWM;
-    if(dwPidResult < 0)
-    {
-        nBasePWM = -nBasePWM;
-    }
-    SWORD nLeftPWM = nBasePWM + (dwPidResult / 1000); // 1000で割るのは、PID制御のゲインが0.01単位のパーセントなので
-    SWORD nRightPWM = nBasePWM - (dwPidResult / 1000);
-    printf("LineTrace::executeTrace() called. Left PWM: %d, Right PWM: %d\n", nLeftPWM, nRightPWM);
+
+    /* 1000で割るのは、PID制御のゲインが0.01単位のパーセントなので */
+    SWORD nLeftPWM = TOP_PWM - (dwPidResult / 1000);
+    SWORD nRightPWM = TOP_PWM + (dwPidResult / 1000);
+
+    /* メモ: Pid出力が20000以上だと完全にコース外にいる */
+    // printf("Left PWM: %d, Right PWM: %d, PidResult: %d\n", nLeftPWM, nRightPWM, dwPidResult);
     m_pWalker->setPWMForLineTrace(nRightPWM, nLeftPWM);
 
     return eNextState;
@@ -62,10 +74,10 @@ Common::ExecuteState LineTrace::executeTrace(void)
 
 
 Common::ExecuteState LineTrace::Run(void) {
-    printf("go LineTrace\n");
     switch (m_eExecuteState)
     {
     case Common::ExecuteState::Init:
+        printf("LineTrace start\n");
         m_eExecuteState = excuteInitWalk();
         break;
 

--- a/src/right/app/lineTrace.cpp
+++ b/src/right/app/lineTrace.cpp
@@ -42,20 +42,13 @@ Common::ExecuteState LineTrace::excuteInitWalk(void)
     /* TODO: ono ライントレース開始時の固定Runなかったかな？ */
     return Common::ExecuteState::Execute;
 }
-static bool isRunEnd = false;
+
 Common::ExecuteState LineTrace::executeTrace(void)
 {
     Common::ExecuteState eNextState = Common::ExecuteState::Execute;
-    if(isRunEnd) {
-        m_pWalker->setPWMForLineTrace(0, 0);
-        return eNextState;
-    }
     /* 青色を検知で終了 */
     if(m_pLineMonitor->isLineDetected(m_stColorTh_Max.wR, m_stColorTh_Max.wG, m_stColorTh_Max.wB, m_stColorTh_Min.wR, m_stColorTh_Min.wG, m_stColorTh_Min.wB)) {
-        // eNextState = Common::ExecuteState::End;
-        m_pWalker->setPWMForLineTrace(0, 0);
-        isRunEnd = true;
-        return eNextState;
+        eNextState = Common::ExecuteState::End;
     }
 
     /* Pid演算タスク */

--- a/src/right/app/lineTrace.h
+++ b/src/right/app/lineTrace.h
@@ -23,12 +23,12 @@ class LineTrace
         } ST_COLOR_TH;
         LineTrace(Walker* pWalker, LineMonitor* pLineMonitor);
         Common::ExecuteState Run(void);
-        void setColorTh(ST_COLOR_TH* pstColorTh);
     private:
         Walker* m_pWalker;
         LineMonitor* m_pLineMonitor;
         Caculation::PidCtrl* m_pidCtrl;
-        ST_COLOR_TH m_stColorTh;
+        ST_COLOR_TH m_stColorTh_Max;
+        ST_COLOR_TH m_stColorTh_Min;
         Common::ExecuteState m_eExecuteState;
         Common::ExecuteState executeTrace(void);
         Common::ExecuteState excuteInitWalk(void);

--- a/src/right/app/scenarioTrace.cpp
+++ b/src/right/app/scenarioTrace.cpp
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include "scenarioTrace.h"
 
-#define DEFAULT_STRAIGHT_PWM (100) // デフォルトの前進時PWM値
+#define DEFAULT_STRAIGHT_PWM (200) // デフォルトの前進時PWM値
 static WORD straight_pwm = DEFAULT_STRAIGHT_PWM; // 設定可能な前進時PWM値
 
 
@@ -138,17 +138,26 @@ void ScenarioTrace::executeWalking(void)
     {
         case eCOMMAND_STRAIGHT:
             /* 前進 */
+            printf("Straight:Current RightPWM:%d, Current LeftPWM:%d\n", 
+                straight_pwm, straight_pwm
+            );
             m_pWalker->runForward(straight_pwm, straight_pwm);
-            break;
-
-        case eCOMMAND_RIGHT:
-            /* 右回転 */
-            m_pWalker->runForward(straight_pwm + m_stParams[m_stWork.byExeParamsIndex].nRightBias, 
-                                  straight_pwm - m_stParams[m_stWork.byExeParamsIndex].nLeftBias);
             break;
 
         case eCOMMAND_LEFT:
             /* 左回転 */
+            printf("LEFT: Current RightPWM:%d, Current LeftPWM:%d\n", 
+                straight_pwm + m_stParams[m_stWork.byExeParamsIndex].nRightBias,
+                straight_pwm - m_stParams[m_stWork.byExeParamsIndex].nLeftBias);
+            m_pWalker->runForward(straight_pwm + m_stParams[m_stWork.byExeParamsIndex].nRightBias, 
+                                  straight_pwm - m_stParams[m_stWork.byExeParamsIndex].nLeftBias);
+            break;
+
+        case eCOMMAND_RIGHT:
+            /* 右回転 */
+            printf("RIGHT: Current RightPWM:%d, Current LeftPWM:%d\n", 
+                straight_pwm - m_stParams[m_stWork.byExeParamsIndex].nRightBias,
+                straight_pwm + m_stParams[m_stWork.byExeParamsIndex].nLeftBias);
             m_pWalker->runForward(straight_pwm - m_stParams[m_stWork.byExeParamsIndex].nRightBias, 
                                   straight_pwm + m_stParams[m_stWork.byExeParamsIndex].nLeftBias);
             break;


### PR DESCRIPTION
このプルリクエストでは、ロボットのライントレースおよびシナリオトレースロジックに対し、機能面と構造面の両方で複数の改善を導入するとともに、しきい値処理とデバッグ出力のリファクタリングを実施します。主な変更点として、カラーしきい値検出の強化、PID制御と車輪停止ロジックの見直し、シナリオおよびタスクシーケンス管理の更新、テストと分析を容易にするデバッグ出力の改善が含まれます。

**ライン追跡と色検出の改善:**

* `LineMonitor` および `LineTrace` をリファクタリングし、ライン検出用に独立した最小/最大RGB閾値を使用するように変更。精度と柔軟性が向上。関連メソッドは6つのしきい値パラメータを受け取るようになり、内部ロジックもそれに応じて更新されました。(`src/common/app/lineMonitor.cpp`, `src/common/app/lineMonitor.h`, `src/right/app/lineTrace.cpp`, `src/right/app/lineTrace.h`) [[1]](diffhunk://# diff-5a6f9456e8202c56f17266d304af629ce8eaedb14e20448d6c28a86fdbd376e9L15-R35) [[2]](diffhunk://# diff-ec5c363f4bfe2efdb51a196b8d007de42e61d555027ac115a6d8a873d5658445L11-R16) [[3]](diffhunk://# diff-f93af8889303e4cbc3be0a991f102a681d5187edd8dfd84b76834b4fbbee0fe9L24-L28) [[4]](diffhunk://# diff-ea8e99963ef74f2e4a940f55d728b9843b82515d81c70d4148ff86d19349ebedL26-R31)
* `LineTrace::executeTrace` 内の PID 制御出力と PWM 計算ロジックを更新し、計算を簡素化するとともに、左右車輪制御の方向ロジックを明確化しました。(`src/right/app/lineTrace.cpp`)

**シナリオ/タスクシーケンスとパラメータの更新:**

* `rightMain.cpp` のシナリオパラメータとタスクシーケンスロジックを改訂し、シナリオ遷移、タスク初期化、目標検出を明確化。各段階に追加のデバッグ出力を含める。(`src/right/rightMain.cpp`) [[1]](diffhunk://# diff-1f048e82dd584d040833b688ebc4db072596c86fec51ad41381f31e47ec91963L15-R28) [[2]](diffhunk://# diff-1f048e82dd584d040833b688ebc4db072596c86fec51ad41381f31e47ec91963R60) [[3]](diffhunk://# diff-1f048e82dd584d040833b688ebc4db072596c86fec51ad41381f31e47ec91963L76-R103) [[4]](diffhunk://# diff-1f048e82dd584d040833b688ebc4db072596c86fec51ad41381f31e47ec91963L124-R129)
* シナリオトレース時のデフォルト直進PWM値を増加し、ロボット速度を向上させた。(`src/right/app/scenarioTrace.cpp`)
* シナリオトレースにおける左/右旋回のコマンド処理とデバッグ出力を修正し、明確性と正確性を向上させた。(`src/right/app/scenarioTrace.cpp`)

**車輪制御とPIDデバッグ:**

* `Walker`の車輪停止ロジックを`stop()`から`setPower(0)`に変更し、車輪制御を標準化しました。(`src/common/mid/walker.cpp`)
* テスト容易化のため、コードベース全体でデバッグ出力文をコメントアウトまたは追加（PID計算やタイマータイムアウトイベントを含む）。(`src/common/app/pidCtrl.cpp`, `src/common/mid/timer.cpp`, `src/right/app/lineTrace.cpp`, `src/right/rightMain.cpp`) [[1]](diffhunk://# diff-3cb5d224611527cb18b1eb16ef5c281023b5f5f2fe48bbfd2a9dcddf64733585L40-R41) [[2]](diffhunk://# diff-660ac3a924e722e0fa64d1942f7460acab1663bdf3198e506638ed30c6a874dcR50-R51) [[3]](diffhunk://# diff-f93af8889303e4cbc3be0a991f102a681d5187edd8dfd84b76834b4fbbee0fe9L42-R73) [[4]](diffhunk://# diff-1f048e82dd584d040833b688ebc4db072596c86fec51ad41381f31e47ec91963L173-R178)

これらの変更は、ロボット制御ソフトウェアの堅牢性、保守性、およびテスト可能性を総合的に向上させます。